### PR TITLE
ISSUE #21 Adds support for omit symbol

### DIFF
--- a/src/htmlCanvas.js
+++ b/src/htmlCanvas.js
@@ -26,6 +26,8 @@ define(
 		// Supported HTML events
 		var attributes = 'href for id media rel src style title type'.split(' ');
 
+		var omitSymbol = {};
+
 		// Supported HTML attributes
 		var events = ('blur focus focusin focusout load resize scroll unload ' +
 			'click dblclick mousedown mouseup mousemove mouseover ' +
@@ -114,6 +116,16 @@ define(
 					return that.tag(tagName, args);
 				};
 			});
+
+			/**
+			 * Returns omit symbol that is used to omit a attribute pair
+			 * and omit the object appended to brush.
+			 *
+			 * @returns {{}}
+			 */
+			that.omit = function() {
+				return omitSymbol;
+			};
 
 			/**
 			 * Append an object to the root brush
@@ -291,6 +303,11 @@ define(
 			 * @returns {{}}
 			 */
 			that.setAttribute = function (key, value) {
+				// Omit attribute if value is omit
+				if(value === omitSymbol) {
+					return that;
+				}
+
 				element.setAttribute(key, value);
 				return that;
 			};
@@ -421,6 +438,11 @@ define(
 			function append(object) {
 				if (typeof(object) === 'undefined' || object === null) {
 					throw new Error('cannot append null or undefined to brush');
+				}
+
+				// Ignore object if it's a omit symbol
+				if(object === omitSymbol) {
+					return;
 				}
 
 				if (typeof object === "object" && object.constructor === Array) {

--- a/test/htmlCanvasTest.js
+++ b/test/htmlCanvasTest.js
@@ -81,7 +81,21 @@ define(["widgetjs/htmlCanvas", "jquery", "chai"], function(htmlCanvas, jQuery, c
             assert.equal(divEl.attr('class'), 'test_class', 'attribute class rendered');
 
             // and class was set
-            assert.equal(divEl.attr('special_attribute'), 'test', 'attribute special_attribute rendered');
+            assert.ok(divEl.is('[special_attribute]'), 'attribute special_attribute rendered');
+        });
+    });
+
+    test("can omit attributes", function() {
+        withCanvas(function(html) {
+            // Arrange: a div with attributes
+            html.div({id: 'test_div', 'special_attribute' : html.omit()}, 'content');
+
+            // Assert: that DIV was rendered
+            var divEl = jQuery("#test_div");
+            assert.ok(divEl.get(0), 'element rendered');
+
+            // and class was set
+            assert.ok(!divEl.is('[special_attribute]'), 'attribute special_attribute not rendered');
         });
     });
 
@@ -138,6 +152,24 @@ define(["widgetjs/htmlCanvas", "jquery", "chai"], function(htmlCanvas, jQuery, c
             assert.ok(jQuery("#outer_div").get(0), 'outer div rendered');
             assert.ok(jQuery("#inner_div").get(0), 'inner div rendered');
             assert.ok(jQuery("#inner_div > SPAN").get(0), 'inner SPAN rendered');
+        });
+    });
+
+    test("can omit nested tags", function() {
+        withCanvas(function(html) {
+            // Arrange: a inner and outer div with a span as inner child
+            // where the child is omited based on a flag
+            var hasSomeText = false;
+            html.div({'id' : 'outer_div'},
+                html.div({'id' : 'inner_div'},
+                    hasSomeText ? html.span('Some text') : html.omit()
+                )
+            );
+
+            // Assert: that outer div rendered
+            assert.ok(jQuery("#outer_div").get(0), 'outer div rendered');
+            assert.ok(jQuery("#inner_div").get(0), 'inner div rendered');
+            assert.ok(!jQuery("#inner_div > SPAN").get(0), 'inner SPAN not rendered');
         });
     });
 


### PR DESCRIPTION
A symbol used to omit attributes or child nodes

* htmlCanvas.js: Adds symbol and omits omit objects appended as well as attributes with omit as value
* htmlCanvasTest.js: Tests

See ISSUE #21