### PR TITLE
Recursively dispose children of a widget

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -98,6 +98,9 @@ define(
 			 *
 			 */
 			that.dispose = function() {
+				children.forEach(function(child) {
+					child.dispose();
+				});
 				my.disposeWidget();
 			};
 


### PR DESCRIPTION
This uses automatic children registration.

* src/widget.js (that.dispose): dispose children first.