### PR TITLE
willUpdate, didAttach and didAttach hooks

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -202,8 +202,6 @@ define(
 				my.events.dispose();
 			};
 
-			my.trigger = my.events.trigger;
-
 			// Route / Controller extensions
 
 			my.router = router.getRouter();

--- a/src/widget.js
+++ b/src/widget.js
@@ -67,12 +67,6 @@ define(
 			/** Events for widget */
 			my.events = events.eventCategory();
 
-			/**
-			 * Event triggered each time the widget is attached (or
-			 * reattached due to an update of rendering) to the DOM.
-			 */
-			that.didAttach = my.events.createEvent();
-
 			//
 			// Public
 			//
@@ -113,8 +107,9 @@ define(
 			 * @param aJQuery
 			 */
 			that.appendTo = function (aJQuery) {
-				renderBasicOn(htmlCanvas(aJQuery));
-				that.triggerDidAttach();
+				my.withAttachHooks(function() {
+					renderBasicOn(htmlCanvas(aJQuery));
+				});
 			};
 
 			/**
@@ -124,10 +119,11 @@ define(
 			 * @param aJQuery
 			 */
 			that.replace = function (aJQuery) {
-				var canvas = htmlCanvas(aJQuery);
-				canvas.root.asJQuery().empty();
-				renderBasicOn(canvas);
-				that.triggerDidAttach();
+				my.withAttachHooks(function() {
+					var canvas = htmlCanvas(aJQuery);
+					canvas.root.asJQuery().empty();
+					renderBasicOn(canvas);
+				});
 			};
 
 			/**
@@ -161,7 +157,20 @@ define(
 			 * @param aTagBrush
 			 */
 			that.appendToBrush = function (aTagBrush) {
-				renderBasicOn(htmlCanvas(aTagBrush.asJQuery()));
+				my.withAttachHooks(function() {
+					renderBasicOn(htmlCanvas(aTagBrush.asJQuery()));
+				});
+			};
+
+			/**
+			 * Trigger the `willAttach` event on the receiver and all
+			 * rendered subwidgets.
+			 */
+			that.triggerWillAttach = function() {
+				my.willAttach();
+				children.forEach(function (widget) {
+					widget.triggerWillAttach();
+				});
 			};
 
 			/**
@@ -169,10 +178,20 @@ define(
 			 * rendered subwidgets.
 			 */
 			that.triggerDidAttach = function() {
-				that.didAttach.trigger();
+				my.didAttach();
 				children.forEach(function (widget) {
 					widget.triggerDidAttach();
 				});
+			};
+
+			/**
+			 * Evaluate `fn`, calling `willAttach` before and `didAttach` after
+			 * the evaluation.
+			 */
+			my.withAttachHooks = function(fn) {
+				that.triggerWillAttach();
+				fn();
+				that.triggerDidAttach();
 			};
 
 			// Expose events
@@ -306,6 +325,18 @@ define(
 			that.renderContentOn = function (html) {};
 
 			/**
+			 * Hook evaluated before the widget is attached (or reattached due
+			 * to an update of rendering) to the DOM.
+			 */
+			my.willAttach = function() {};
+
+			/**
+			 * Hook evaluated each time the widget is attached (or
+			 * reattached due to an update of rendering) to the DOM.
+			 */
+			my.didAttach = function() {};
+
+			/**
 			 * Hook evaluated before widget update.
 			 */
 			my.willUpdate = function() {};
@@ -323,14 +354,14 @@ define(
 				}
 
 				my.willUpdate();
+				my.withAttachHooks(function() {
+					// Re-render
+					var html = htmlCanvas();
+					renderBasicOn(html);
 
-				// Re-render
-				var html = htmlCanvas();
-				renderBasicOn(html);
-
-				// Replace our self
-				that.asJQuery().replaceWith(html.root.element);
-				that.triggerDidAttach();
+					// Replace our self
+					that.asJQuery().replaceWith(html.root.element);
+				});
 			};
 
 			that.withinTransaction = function(fn, onDone) {

--- a/test/widgetTest.js
+++ b/test/widgetTest.js
@@ -260,4 +260,76 @@ define(["widgetjs/widget", "widgetjs/htmlCanvas", "jquery", "chai"], function(wi
 
         });
     });
+
+	test("willAttach() and didAttach() are called upon rendering", function() {
+        withCanvas(function(html) {
+            var aWidget = (function() {
+                var my = {};
+                var that = widget({}, my);
+
+				that.willAttachCalled = false;
+				that.didAttachCalled = false;
+
+				my.willAttach = function() {
+					that.willAttachCalled = true;
+				};
+
+				my.didAttach = function() {
+					that.didAttachCalled = true;
+				};
+
+                return that;
+            })();
+
+            // Act: render widget
+            html.render(aWidget);
+
+            // Assert: that form is rendered with id
+            assert.ok(aWidget.willAttachCalled);
+            assert.ok(aWidget.didAttachCalled);
+        });
+    });
+
+	test("willUpdate() is not called when rendering", function() {
+        withCanvas(function(html) {
+            var aWidget = (function() {
+                var my = {};
+                var that = widget({}, my);
+
+				that.willUpdateCalled = false;
+
+				my.willUpdate = function() {
+					that.willUpdateCalled = true;
+				};
+
+                return that;
+            })();
+
+            html.render(aWidget);
+
+            assert.ok(!aWidget.willUpdateCalled);
+        });
+	});
+
+	test("willUpdate() is called when updating", function() {
+        withCanvas(function(html) {
+            var aWidget = (function() {
+                var my = {};
+                var that = widget({}, my);
+
+				that.willUpdateCalled = false;
+
+				my.willUpdate = function() {
+					that.willUpdateCalled = true;
+				};
+
+                return that;
+            })();
+
+            html.render(aWidget);
+			aWidget.update();
+
+            assert.ok(aWidget.willUpdateCalled);
+        });
+	});
 });

--- a/test/widgetTest.js
+++ b/test/widgetTest.js
@@ -55,7 +55,7 @@ define(["widgetjs/widget", "widgetjs/htmlCanvas", "jquery", "chai"], function(wi
             var that = widget({}, my);
 
             that.aMethod = function() {
-                my.trigger('anEvent');
+                that.trigger('anEvent');
             };
 
             return that;
@@ -80,7 +80,7 @@ define(["widgetjs/widget", "widgetjs/htmlCanvas", "jquery", "chai"], function(wi
             that.onAnEvent = my.events.createEvent('anEvent');
 
             that.aMethod = function() {
-                my.trigger('anEvent');
+                that.trigger('anEvent');
             };
 
             return that;


### PR DESCRIPTION
Add willAttach and didAttach hook functions

When a widget is being attached to the DOM, run two hooks: `willAttach`
and `didAttach`.  The first one is evaluated before rendering, and the
second one just after.
